### PR TITLE
Video proof support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-img_tmp/*.jpg
-img_tmp/*.png
-img_tmp/*.mp4
+img_temp/*jpg
+img_temp/*png
+img_temp/*mp4
 devel/
 logs/
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+img_tmp/*.jpg
+img_tmp/*.png
+img_tmp/*.mp4
 devel/
 logs/
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(scavenger_interface)
 add_compile_options(-std=c++11)
 
 find_package(OpenCV 3 REQUIRED COMPONENTS)
-find_package(catkin REQUIRED COMPONENTS cv_bridge roscpp scavenger_hunt_msgs sensor_msgs darknet_ros_msgs)
+find_package(catkin REQUIRED COMPONENTS cv_bridge roscpp roslib scavenger_hunt_msgs sensor_msgs darknet_ros_msgs)
 
 catkin_package()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.0.2)
 project(scavenger_interface)
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED COMPONENTS roscpp scavenger_hunt_msgs sensor_msgs darknet_ros_msgs)
+find_package(OpenCV 3 REQUIRED COMPONENTS)
+find_package(catkin REQUIRED COMPONENTS cv_bridge roscpp scavenger_hunt_msgs sensor_msgs darknet_ros_msgs)
 
 catkin_package()
 
@@ -11,6 +12,8 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(scavenger_ros_interface src/scavenger_ros_interface.cpp)
 add_library(passive_hunter src/passive_hunter.cpp)
 
+target_link_libraries(passive_hunter ${OpenCV_LIBS} ${catkin_LIBRARIES})
+
 add_executable(hunter_launcher src/hunter_launcher.cpp)
-add_dependencies(hunter_launcher passive_hunter scavenger_ros_interface)
 target_link_libraries(hunter_launcher ${catkin_LIBRARIES} scavenger_ros_interface passive_hunter)
+add_dependencies(hunter_launcher passive_hunter scavenger_ros_interface)

--- a/include/passive_hunter.h
+++ b/include/passive_hunter.h
@@ -1,4 +1,7 @@
+#include <cv_bridge/cv_bridge.h>
 #include <darknet_ros_msgs/BoundingBoxes.h>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/opencv.hpp>
 #include <ros/ros.h>
 
 #include "hunter.h"
@@ -28,5 +31,6 @@ public:
 	 */
 	void load_classes(scavenger_hunt_msgs::Task task) const;
 	void rgb_image_cb(sensor_msgs::Image msg);
+	void write_image(sensor_msgs::Image image, std::string path) const;
 	void yolo_bb_cb(darknet_ros_msgs::BoundingBoxes msg);
 };  

--- a/launch/scavenger_interface.launch
+++ b/launch/scavenger_interface.launch
@@ -1,11 +1,9 @@
 <launch>
-  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find scavenger_interface)/rosconsole.conf"/>
-
    <!-- name of the hunt to execute -->
    <arg name="hunt_name" default=""/>
 
    <!-- RGB image topic for image tasks -->
-   <arg name="image_topic" default="/darknet_ros/detection_image"/>
+   <arg name="image_topic" default="/camera/rgb/image_raw"/>
 
    <!-- topic for image detection: yolo, etc -->
    <arg name="image_detection_topic" default="/darknet_ros/bounding_boxes"/>
@@ -17,7 +15,7 @@
 
    <include file="$(find scavenger_hunt)/launch/scavenger_hunt.launch"/>
 
-   <node name="huntLauncher" type="huntLauncher" pkg="scavenger_interface" output="screen">
+   <node name="hunter_launcher" type="hunter_launcher" pkg="scavenger_interface" output="screen">
 	<param name="hunt_name" value="$(arg hunt_name)"/>
 	<param name="image_topic" value="$(arg image_topic)"/>
 	<param name="image_detection_topic" value="$(arg image_detection_topic)"/>

--- a/package.xml
+++ b/package.xml
@@ -12,14 +12,20 @@
 
   <author email="maxwell@cs.utexas.edu">Maxwell Svetlik</author> -->
 
-
+  <depend>OpenCV</depend>
   <depend>roscpp</depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>darknet_ros_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>scavenger_hunt_msgs</build_depend>
   <build_depend>message_generation</build_depend>
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <build_depend>roslib</build_depend>
+
+  <exec_depend>ffmpeg</exec_depend>
+  <exec_depend>libavcodec-dev</exec_depend>
+  <exec_depend>libavformat-dev</exec_depend>
+  <exec_depend>libavutil-dev</exec_depend>
+  <exec_depend>libswscale-dev</exec_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
 


### PR DESCRIPTION
This adds initial video proof support using OpenCV and `ffmpeg` to create a video from an image sequence. 

It also catches a bug as residue from the stylistic name changes from #3.

Closes #1 